### PR TITLE
Update run.sh to fix 2 run time errors

### DIFF
--- a/node-scenarios/run.sh
+++ b/node-scenarios/run.sh
@@ -10,10 +10,10 @@ source /root/common_run.sh
 checks
 
 # Substitute config with environment vars defined
-if [[ $CLOUD_TYPE == "vmware"]]; then
+if [[ "$CLOUD_TYPE" == "vmware" ]]; then
   envsubst < /root/kraken/scenarios/vmware_node_scenario.yaml.template > /root/kraken/scenarios/node_scenario.yaml
   export SCENARIO_TYPE="plugin_scenarios"
-  export ACTION=${ACTION:=node_stop_scenario"}
+  export ACTION=${ACTION:="node_stop_scenario"}
 else
   envsubst < /root/kraken/scenarios/node_scenario.yaml.template > /root/kraken/scenarios/node_scenario.yaml
 fi


### PR DESCRIPTION
Modified 2 syntax issues.

if [[ $CLOUD_TYPE == "vmware"]]; then    <<< Requires space between " and ]
Also quoted $CLOUD_TYPE variable so it doesn't error off if CLOUD_TYPE is not initialized
New version >>>>:   if [[ "$CLOUD_TYPE" == "vmware" ]]; then

This line is missing a balanced quote:
export ACTION=${ACTION:=node_stop_scenario"}
New version >>>> export ACTION=${ACTION:="node_stop_scenario"}